### PR TITLE
fix voxelData is not defined

### DIFF
--- a/src/chunkHandlers/XYZI.js
+++ b/src/chunkHandlers/XYZI.js
@@ -4,7 +4,7 @@ module.exports = function XYZIHandler(state, startIndex, endIndex){
   var numVoxels = Math.abs(state.Buffer.readInt32LE(state.readByteIndex));
   state.readByteIndex += 4;
 
-  voxelData = []
+  var voxelData = []
   for (var n = 0; n < numVoxels; n++) {
     voxelData[n] = {
       x: state.Buffer[state.readByteIndex++] & 0xFF,


### PR DESCRIPTION
just missing `var`

<details><summary>Chrome error messages</summary>

```log
XYZI.js:7 Uncaught (in promise) ReferenceError: voxelData is not defined
    at Object.XYZIHandler [as XYZI] (XYZI.js:7)
    at getChunkData (getChunkData.js:31)
    at recReadChunksInRange (recReadChunksInRange.js:33)
    at recReadChunksInRange (recReadChunksInRange.js:54)
    at recReadChunksInRange (recReadChunksInRange.js:46)
    at parseMagicaVoxel2 (index.js:21)
    at main (main.ts:18)
```
</details>